### PR TITLE
Fix `del` on configured store

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Returns promise that resolve to object keys
 
 Returns promise but deletes content of key.
 
-### clear(key)
+### clear()
 
 Returns promise and clears everything in cache.
 
@@ -113,6 +113,7 @@ cache.getAll().then(data => {
 
 ## Change log
 
+- `3.0.2`: Fixed `configuredCache.del` to actually work
 - `3.0.1`: doc fix
 - `3.0.0`: idb-keyval was not being transpiled to es5 causing `class` to be used in the final bundle of some of my apps. Turns off compression and minification of build, that's a concern for final packaging.
 - `2.1.0`: Added support for passing `name` option to `.getConfiguredCache()` to name the IDB database.

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ export const getConfiguredCache = spec => {
     get: key => get(key, opts, store),
     set: (key, val) => set(key, val, opts, store),
     getAll: () => getAll(opts, store),
-    del: () => opts.lib.del(store),
+    del: key => opts.lib.del(key, store),
     clear: () => opts.lib.clear(store),
     keys: () => opts.lib.keys(store)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "money-clip",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-clip",
   "description": "For managing your client side cache. Tiny wrapper over IndexedDB supporting versioning and max age.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Henrik Joreteg <henrik@joreteg.com> (joreteg.com)",
   "bugs": {
     "url": "https://github.com/HenrikJoreteg/money-clip/issues"

--- a/test.js
+++ b/test.js
@@ -95,18 +95,20 @@ test('getConfiguredCache', t => {
 
   cache
     .set('thing', 'value')
+    .then(() => cache.set('thing2', 'value2'))
     .then(() => cache.get('thing'))
     .then(val => {
       t.equal(val, 'value')
       // now try with passing in version manually
       // to show the options were actually used
       // when using pre-configured cache
-      return clip.get('thing', { lib, version: 5 })
+      return clip.get('thing2', { lib, version: 5 })
     })
     .then(val => {
-      t.equal(val, 'value')
-      return cache.getAll()
+      t.equal(val, 'value2')
+      return cache.del('thing2')
     })
+    .then(() => cache.getAll())
     .then(res => {
       t.deepEqual(res, { thing: 'value' }, 'first should return')
       return getWaitPromise(() => cache.getAll())


### PR DESCRIPTION
It didn't pass the key forward to `idb-keyval`.

Thus leaving it kinda noop-ish. Also fixes related-ish bug in documentation saying that clear takes a key, which it doesn't.